### PR TITLE
Component can have Argument as Element 

### DIFF
--- a/main/src/main/java/eu/monnetproject/lemon/impl/ComponentImpl.java
+++ b/main/src/main/java/eu/monnetproject/lemon/impl/ComponentImpl.java
@@ -30,9 +30,8 @@ import eu.monnetproject.lemon.LemonModel;
 import eu.monnetproject.lemon.LinguisticOntology;
 import eu.monnetproject.lemon.impl.io.ReaderAccepter;
 import eu.monnetproject.lemon.model.Component;
-import eu.monnetproject.lemon.model.LexicalEntry;
+import eu.monnetproject.lemon.model.LeafElement;
 import java.net.URI;
-import java.util.Collection;
 
 /**
  * Instantiated via {@link LemonFactoryImpl}
@@ -51,12 +50,12 @@ public class ComponentImpl extends LemonElementImpl<ComponentImpl> implements Co
     }
 
     @Override
-    public LexicalEntry getElement() {
-        return (LexicalEntry) getStrElem(ELEMENT);
+    public LeafElement getElement() {
+        return (LeafElement) getStrElem(ELEMENT);
     }
 
     @Override
-    public void setElement(final LexicalEntry element) {
+    public void setElement(final LeafElement element) {
         setStrElem(ELEMENT, element);
     }
 

--- a/main/src/main/java/eu/monnetproject/lemon/model/Argument.java
+++ b/main/src/main/java/eu/monnetproject/lemon/model/Argument.java
@@ -30,7 +30,7 @@ package eu.monnetproject.lemon.model;
  * An argument of a syntactic frame/semantic predicate
  * @author John McCrae
  */
-public interface Argument extends PhraseTerminal {
+public interface Argument extends PhraseTerminal, LeafElement {
 	/** Get the marker that indicates the syntactic role */
 	SyntacticRoleMarker getMarker();
 	/** Set the marker that indicates the syntactic role */

--- a/main/src/main/java/eu/monnetproject/lemon/model/Component.java
+++ b/main/src/main/java/eu/monnetproject/lemon/model/Component.java
@@ -32,7 +32,7 @@ package eu.monnetproject.lemon.model;
  */
 public interface Component extends PhraseTerminal {
 	/** Get the base lexical entry for this component */ 
-	LexicalEntry getElement();
+	LeafElement getElement();
 	/** Set the base lexical entry for this component */ 
-	void setElement(final LexicalEntry element);
+	void setElement(final LeafElement element);
 }

--- a/main/src/main/java/eu/monnetproject/lemon/model/LeafElement.java
+++ b/main/src/main/java/eu/monnetproject/lemon/model/LeafElement.java
@@ -1,0 +1,5 @@
+package eu.monnetproject.lemon.model;
+
+public interface LeafElement extends LemonElement {
+
+}

--- a/main/src/main/java/eu/monnetproject/lemon/model/LexicalEntry.java
+++ b/main/src/main/java/eu/monnetproject/lemon/model/LexicalEntry.java
@@ -34,7 +34,7 @@ import java.util.Map;
  * The lexical entry is the main representation of a term or word
  * @author John McCrae
  */
-public interface LexicalEntry extends SyntacticRoleMarker {
+public interface LexicalEntry extends SyntacticRoleMarker, LeafElement {
 	/** Get the canonical form of the entry */
 	LexicalForm getCanonicalForm();
 	/** Set the canonical form of the entry */


### PR DESCRIPTION
According to the lemon cookbook a Component can have either LexicalEntry or Argument as its element. To enable this I introduced a supertype for Argument and LexicalEntry called LeafElement and modified Component to accommodate this new supertype.
