### PR TITLE
"Possesive" should be "Possessive"

### DIFF
--- a/main/src/main/resources/lexinfo.owl
+++ b/main/src/main/resources/lexinfo.owl
@@ -1061,18 +1061,18 @@ In 1951: Any editorial comment.</rdfs:comment>
     
 
 
-    <!-- http://www.lexinfo.net/ontology/2.0/lexinfo#possesiveAdjunct -->
+    <!-- http://www.lexinfo.net/ontology/2.0/lexinfo#possessiveAdjunct -->
 
-    <owl:ObjectProperty rdf:about="&lexinfo;possesiveAdjunct">
-        <rdfs:range rdf:resource="&lexinfo;PossesiveAdjunct"/>
+    <owl:ObjectProperty rdf:about="&lexinfo;possessiveAdjunct">
+        <rdfs:range rdf:resource="&lexinfo;possessiveAdjunct"/>
         <rdfs:subPropertyOf rdf:resource="&lexinfo;adjunct"/>
     </owl:ObjectProperty>
     
 
 
-    <!-- http://www.lexinfo.net/ontology/2.0/lexinfo#possesiveInfinitiveClause -->
+    <!-- http://www.lexinfo.net/ontology/2.0/lexinfo#possessiveInfinitiveClause -->
 
-    <owl:ObjectProperty rdf:about="&lexinfo;possesiveInfinitiveClause">
+    <owl:ObjectProperty rdf:about="&lexinfo;possessiveInfinitiveClause">
         <rdfs:subPropertyOf rdf:resource="&lexinfo;clausalArg"/>
     </owl:ObjectProperty>
     
@@ -3325,9 +3325,9 @@ he GAVE a present TO his mother</example>
     
 
 
-    <!-- http://www.lexinfo.net/ontology/2.0/lexinfo#NounPossesiveFrame -->
+    <!-- http://www.lexinfo.net/ontology/2.0/lexinfo#NounPossessiveFrame -->
 
-    <owl:Class rdf:about="&lexinfo;NounPossesiveFrame">
+    <owl:Class rdf:about="&lexinfo;NounPossessiveFrame">
         <owl:equivalentClass>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
@@ -3337,8 +3337,8 @@ he GAVE a present TO his mother</example>
                         <owl:minCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:minCardinality>
                     </owl:Restriction>
                     <owl:Restriction>
-                        <owl:onProperty rdf:resource="&lexinfo;possesiveAdjunct"/>
-                        <owl:onClass rdf:resource="&lexinfo;PossesiveAdjunct"/>
+                        <owl:onProperty rdf:resource="&lexinfo;possessiveAdjunct"/>
+                        <owl:onClass rdf:resource="&lexinfo;PossessiveAdjunct"/>
                         <owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:minQualifiedCardinality>
                     </owl:Restriction>
                 </owl:intersectionOf>
@@ -3485,9 +3485,9 @@ he GAVE a present TO his mother</example>
     
 
 
-    <!-- http://www.lexinfo.net/ontology/2.0/lexinfo#PossesiveAdjunct -->
+    <!-- http://www.lexinfo.net/ontology/2.0/lexinfo#PossessiveAdjunct -->
 
-    <owl:Class rdf:about="&lexinfo;PossesiveAdjunct">
+    <owl:Class rdf:about="&lexinfo;PossessiveAdjunct">
         <rdfs:subClassOf rdf:resource="&lexinfo;Adjunct"/>
     </owl:Class>
     

--- a/main/src/main/resources/lexinfo/examples
+++ b/main/src/main/resources/lexinfo/examples
@@ -24,7 +24,7 @@ http://www.lexinfo.net/ontology/2.0/lexinfo#DitransitiveDoubleAccusativeFrame	de
 http://www.lexinfo.net/ontology/2.0/lexinfo#ReflexiveDativeTransitiveFrame	de	ich TUE mir WEH
 http://www.lexinfo.net/ontology/2.0/lexinfo#AdjectiveInfinitiveFrame	en	she was ABLE [to climb the mountain]
 http://www.lexinfo.net/ontology/2.0/lexinfo#IntransitivePPFrame	en	he TOOK CARE OF her
-http://www.lexinfo.net/ontology/2.0/lexinfo#NounPossesiveFrame	en	the CAPITAL OF france is paris
+http://www.lexinfo.net/ontology/2.0/lexinfo#NounPossessiveFrame	en	the CAPITAL OF france is paris
 http://www.lexinfo.net/ontology/2.0/lexinfo#TransitiveInfinitiveSCFrame	en	john PROMISED mary [to resign]
 http://www.lexinfo.net/ontology/2.0/lexinfo#IntransitiveAdjectivalComplementFrame	en	his reputation SANK low
 http://www.lexinfo.net/ontology/2.0/lexinfo#AdjectiveComparativeFrame	en	new york is BIGGER THAN berlin

--- a/main/src/main/resources/lexinfo/frameClasses
+++ b/main/src/main/resources/lexinfo/frameClasses
@@ -28,7 +28,7 @@ DitransitiveDoubleAccusativeFrame	http://www.lexinfo.net/ontology/2.0/lexinfo#Di
 TransitiveDeclarativeFrame	http://www.lexinfo.net/ontology/2.0/lexinfo#TransitiveDeclarativeFrame
 ReflexiveTransitiveFrame	http://www.lexinfo.net/ontology/2.0/lexinfo#ReflexiveTransitiveFrame
 TransitiveNominalComplementFrame	http://www.lexinfo.net/ontology/2.0/lexinfo#TransitiveNominalComplementFrame
-NounPossesiveFrame	http://www.lexinfo.net/ontology/2.0/lexinfo#NounPossesiveFrame
+NounPossessiveFrame	http://www.lexinfo.net/ontology/2.0/lexinfo#NounPossessiveFrame
 ReflexiveTransitivePPFrame	http://www.lexinfo.net/ontology/2.0/lexinfo#ReflexiveTransitivePPFrame
 PrepositionFrame	http://www.lexinfo.net/ontology/2.0/lexinfo#PrepositionFrame
 TransitiveSententialFrame	http://www.lexinfo.net/ontology/2.0/lexinfo#TransitiveSententialFrame

--- a/main/src/main/resources/lexinfo/synArgs
+++ b/main/src/main/resources/lexinfo/synArgs
@@ -12,9 +12,9 @@ complement	http://www.lexinfo.net/ontology/2.0/lexinfo#complement
 attributiveArg	http://www.lexinfo.net/ontology/2.0/lexinfo#attributiveArg
 clausalArg	http://www.lexinfo.net/ontology/2.0/lexinfo#clausalArg
 copulativeSubject	http://www.lexinfo.net/ontology/2.0/lexinfo#copulativeSubject
-possesiveAdjunct	http://www.lexinfo.net/ontology/2.0/lexinfo#possesiveAdjunct
+possessiveAdjunct	http://www.lexinfo.net/ontology/2.0/lexinfo#possessiveAdjunct
 prepositionalInterrogativeClause	http://www.lexinfo.net/ontology/2.0/lexinfo#prepositionalInterrogativeClause
-possesiveInfinitiveClause	http://www.lexinfo.net/ontology/2.0/lexinfo#possesiveInfinitiveClause
+possessiveInfinitiveClause	http://www.lexinfo.net/ontology/2.0/lexinfo#possessiveInfinitiveClause
 objectComplement	http://www.lexinfo.net/ontology/2.0/lexinfo#objectComplement
 synArg	http://lemon-model.net/lemon#synArg
 postPositiveArg	http://www.lexinfo.net/ontology/2.0/lexinfo#postPositiveArg

--- a/main/src/main/resources/lexinfo/synArgsByFrame
+++ b/main/src/main/resources/lexinfo/synArgsByFrame
@@ -27,7 +27,7 @@ http://www.lexinfo.net/ontology/2.0/lexinfo#ReflexiveDativeTransitiveFrame http:
 http://www.lexinfo.net/ontology/2.0/lexinfo#DitransitiveDoubleAccusativeFrame http://www.lexinfo.net/ontology/2.0/lexinfo#subject http://www.lexinfo.net/ontology/2.0/lexinfo#directObject
 http://www.lexinfo.net/ontology/2.0/lexinfo#IntransitivePPFrame http://www.lexinfo.net/ontology/2.0/lexinfo#subject http://www.lexinfo.net/ontology/2.0/lexinfo#prepositionalAdjunct
 http://www.lexinfo.net/ontology/2.0/lexinfo#AdjectiveInfinitiveFrame http://www.lexinfo.net/ontology/2.0/lexinfo#infinitiveClause http://www.lexinfo.net/ontology/2.0/lexinfo#copulativeSubject
-http://www.lexinfo.net/ontology/2.0/lexinfo#NounPossesiveFrame http://www.lexinfo.net/ontology/2.0/lexinfo#possesiveAdjunct http://www.lexinfo.net/ontology/2.0/lexinfo#copulativeArg
+http://www.lexinfo.net/ontology/2.0/lexinfo#NounPossessiveFrame http://www.lexinfo.net/ontology/2.0/lexinfo#possessiveAdjunct http://www.lexinfo.net/ontology/2.0/lexinfo#copulativeArg
 http://www.lexinfo.net/ontology/2.0/lexinfo#AdjectiveFrame
 http://www.lexinfo.net/ontology/2.0/lexinfo#TransitiveInfinitiveSCFrame http://www.lexinfo.net/ontology/2.0/lexinfo#subject http://www.lexinfo.net/ontology/2.0/lexinfo#directObject http://www.lexinfo.net/ontology/2.0/lexinfo#infinitiveClause
 http://www.lexinfo.net/ontology/2.0/lexinfo#IntransitiveAdjectivalComplementFrame http://www.lexinfo.net/ontology/2.0/lexinfo#subject http://www.lexinfo.net/ontology/2.0/lexinfo#predicativeAdjective


### PR DESCRIPTION
Everywhere in the code, the word "_possessive_" is written as "_possesive_", with three 's' instead of four (as it should be correct in english).
This causes problems when this library is used with Lexinfo, where it is properly written as "_possessive_" (e.g. _possessiveAdjunct_ or _possessiveInfinitiveClause_, see here: [http://www.lexinfo.net/ontology/2.0/lexinfo](url) )